### PR TITLE
Refactor corpus update

### DIFF
--- a/data/cre2/build.sh
+++ b/data/cre2/build.sh
@@ -14,7 +14,7 @@ function download() {
     if [[ ! -z "${DOCKER_CONTAINER:-}" ]]; then
         apt-get update &&
             apt-get -y upgrade &&
-            apt-get -y install pkg-config file cmake autoconf automake texinfo &&
+            apt-get -y install pkg-config file cmake autoconf automake texinfo libtool &&
             apt-get clean
     fi
 

--- a/src/deopt.rs
+++ b/src/deopt.rs
@@ -355,6 +355,19 @@ impl Deopt {
         Ok(corpus_dir)
     }
 
+    pub fn get_library_shared_corpus_profraw_dir(&self) -> Result<PathBuf> {
+        let temp_dir = self.get_library_misc_dir()?;
+        let profraw_dir: PathBuf = [temp_dir, "profraw".into()].iter().collect();
+        create_dir_if_nonexist(&profraw_dir)?;
+        Ok(profraw_dir)
+    }
+
+    pub fn get_library_shared_corpus_profdata(&self) -> Result<PathBuf> {
+        let temp_dir = self.get_library_misc_dir()?;
+        let profdata = [temp_dir, "default.profdata".into()].iter().collect();
+        Ok(profdata)
+    }
+
     pub fn copy_file_to_shared_corpus(&self, instresting_files: Vec<PathBuf>) -> Result<()> {
         let corpus_dir = self.get_library_shared_corpus_dir()?;
         for file in instresting_files {
@@ -636,6 +649,14 @@ pub mod utils {
         Ok(())
     }
 
+    pub fn count_dir_entires(dir: &Path) -> Result<usize> {
+        if !dir.exists() {
+            return Ok(0);
+        }
+        let entries = std::fs::read_dir(dir)?;
+        Ok(entries.count())
+    }
+
     /// read the directory and sort the entries by the alphabet oder
     pub fn read_sort_dir(dir: &Path) -> Result<Vec<PathBuf>> {
         let mut entries = Vec::new();
@@ -651,6 +672,13 @@ pub mod utils {
         }
         entries.sort();
         Ok(entries)
+    }
+
+    pub fn get_newly_added_files(old_dir: &Path, new_dir: &Path) -> Result<Vec<PathBuf>> {
+        let old_files = read_sort_dir(old_dir)?;
+        let now_files = read_sort_dir(new_dir)?;
+        let new_files: Vec<PathBuf> = now_files.iter().filter(|x| !old_files.contains(x)).cloned().collect();
+       Ok(new_files)
     }
 
     /// format the headers of this library that should include as a single String.

--- a/src/feedback/observer.rs
+++ b/src/feedback/observer.rs
@@ -314,8 +314,8 @@ mod tests {
 
         let profdata: PathBuf = [Deopt::get_crate_dir()?, "testsuites", "corpora", "defualt.profdata"].iter().collect();
         let coverage = Executor::obtain_cov_from_profdata(&executor, &profdata)?;
-        let clang_branch = coverage.get_total_summary().count_covered_branch();
-        let clang_total_branch: usize = coverage.get_total_summary().count_total_branch();
+        let clang_branch = coverage.get_total_summary().count_covered_branches();
+        let clang_total_branch: usize = coverage.get_total_summary().count_total_branches();
         log::info!("clang coverage: covered: {clang_branch}, total: {clang_total_branch}");
 
         let mut observer = Observer::new(&deopt);

--- a/src/program/infer/dynamic_infer.rs
+++ b/src/program/infer/dynamic_infer.rs
@@ -322,7 +322,7 @@ pub fn find_testbed_corpora(program_path: &Path, deopt: &Deopt) -> Result<PathBu
             break;
         }
         let cov = cov?;
-        let cov_score = cov.get_total_summary().count_covered_branch();
+        let cov_score = cov.get_total_summary().count_covered_branches();
         ranked_files.push((cache_file, cov_score));
         if !sanitize_by_fuzzer_coverage(&fuzzer_code, deopt, &cov)? {
             return Ok(cache_file.to_path_buf());
@@ -355,7 +355,7 @@ pub fn find_testbed_corpora(program_path: &Path, deopt: &Deopt) -> Result<PathBu
         if sanitize_by_fuzzer_coverage(&fuzzer_code, deopt, &cov)? {
             continue;
         }
-        let covered_branch = cov.get_total_summary().count_covered_branch();
+        let covered_branch = cov.get_total_summary().count_covered_branches();
         if covered_branch > max_branch {
             max_branch = covered_branch;
             max_corpora = Some(corpora.clone());


### PR DESCRIPTION
Previous updating of corpus was utlized the minimization of the libfuzzer. By using this way, a huge time would be wasted due to the duplicated compution of the same corpus coverage.

In this commit, I refactor the function of corpus evolution by changing it with coverage cache.